### PR TITLE
wic-helper: symlinks in deploy cannot be absolute

### DIFF
--- a/classes/wic-helper.bbclass
+++ b/classes/wic-helper.bbclass
@@ -28,7 +28,7 @@ IMAGE_CMD_emmc () {
 	EMMCIMG=${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.emmc
 	cp ${SDIMG} ${EMMCIMG}
 
-	ln -sf ${EMMCIMG} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.emmc
+	ln -sf ${EMMCIMG} ${IMAGE_LINK_NAME}.emmc
 }
 
 IMAGE_TYPEDEP_emmc = "wic"


### PR DESCRIPTION
Will cause a following sstate error:
| ERROR: custom-image-1.0-r0 do_image_complete: sstate found an
| absolute path symlink .../custom-image-machine.emmc pointing at
| .../custom-image-machine-datetime.rootfs.emmc. Please replace
| this with a relative link.

Signed-off-by: Denys Dmytriyenko <denys@konsulko.com>