### PR TITLE
wic-helper: symlinks in deploy cannot be absolute

### DIFF
--- a/classes/wic-helper.bbclass
+++ b/classes/wic-helper.bbclass
@@ -25,8 +25,8 @@ IMAGE_CMD_emmc () {
 			SDIMG=${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.wic
 		fi
 	fi
-	EMMCIMG=${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.emmc
-	cp ${SDIMG} ${EMMCIMG}
+	EMMCIMG=${IMAGE_NAME}.rootfs.emmc
+	cp ${SDIMG} ${IMGDEPLOYDIR}/${EMMCIMG}
 
 	ln -sf ${EMMCIMG} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.emmc
 }


### PR DESCRIPTION
Will cause a following sstate error:
| ERROR: custom-image-1.0-r0 do_image_complete: sstate found an
| absolute path symlink .../custom-image-machine.emmc pointing at
| .../custom-image-machine-datetime.rootfs.emmc. Please replace
| this with a relative link.

Signed-off-by: Denys Dmytriyenko <denys@konsulko.com>