### PR TITLE
conf: machine: phyimx8.inc: Use lazy expansion or MACHINE_FEATURES is…

### DIFF
--- a/conf/machine/include/phyimx8.inc
+++ b/conf/machine/include/phyimx8.inc
@@ -58,7 +58,7 @@ IMAGE_FSTYPES = " \
     partup \
 "
 
-MACHINE_FEATURES:use-nxp-bsp += "caam optee"
+MACHINE_FEATURES:append:use-nxp-bsp = " caam optee"
 MACHINE_FEATURES:remove:mx8x-nxp-bsp = " optee"
 
 QEMUVERSION = "8.2%"


### PR DESCRIPTION
… reset

When using immediate append (+=) on a variable that is set everywhere else using lazy expansion (append, prepend, remove), the append will in fact create the variable at that moment, and loose all that was configured by lazy expansion up till then.